### PR TITLE
Remove references to google-analytics.html

### DIFF
--- a/_layouts/404.html
+++ b/_layouts/404.html
@@ -17,6 +17,5 @@
   </div>
 </div>
 <script src='{{site.baseurl}}/assets/site.js'></script>
-{% include google-analytics.html %}
 </body>
 </html>

--- a/_layouts/techfar.html
+++ b/_layouts/techfar.html
@@ -33,6 +33,5 @@
 </div>
 
 <script async id="_fed_an_js_tag" type="text/javascript" src="{{site.baseurl}}/assets/js/federated-analytics.all.min.js?agency=EOP&amp;sub-agency=USDS"></script>
-{% include google-analytics.html %}
 </body>
 </html>


### PR DESCRIPTION
As the `google-analytics.html` is not to be included in this repository,
this commit does not add or remove that file, instead it takes away the
references.

If we desire analytics for this repository, we should probably use what
we use elsewhere which is Plausible, or document why not.